### PR TITLE
fix: get address with network version in deserialiser

### DIFF
--- a/lib/arkecosystem/crypto/deserializer.ex
+++ b/lib/arkecosystem/crypto/deserializer.ex
@@ -232,11 +232,11 @@ defmodule ArkEcosystem.Crypto.Deserializer do
 
     transaction = case transaction.type do
       @second_signature_registration ->
-        recipient_id = EcKey.public_key_to_address(transaction.sender_public_key)
+        recipient_id = EcKey.public_key_to_address(transaction.sender_public_key, transaction.network)
         Map.put(transaction, :recipient_id, recipient_id)
 
       @vote ->
-        recipient_id = EcKey.public_key_to_address(transaction.sender_public_key)
+        recipient_id = EcKey.public_key_to_address(transaction.sender_public_key, transaction.network)
         Map.put(transaction, :recipient_id, recipient_id)
 
       @multi_signature_registration ->

--- a/lib/utils/ec_key.ex
+++ b/lib/utils/ec_key.ex
@@ -27,8 +27,6 @@ defmodule ArkEcosystem.Crypto.Utils.EcKey do
   end
 
   def private_key_to_address(private_key, network_address \\ nil) do
-    network_address = network_address || ArkEcosystem.Crypto.Configuration.Network.version
-
     private_key
     |> private_key_to_public_key
     |> public_key_to_address(network_address)
@@ -41,8 +39,6 @@ defmodule ArkEcosystem.Crypto.Utils.EcKey do
   end
 
   def secret_to_address(secret, network_address \\ nil) do
-    network_address = network_address || ArkEcosystem.Crypto.Configuration.Network.version
-
     secret
     |> get_private_key
     |> private_key_to_address(network_address)


### PR DESCRIPTION
Pass the network when deserializing a public key