### PR TITLE
feat: signature verification

### DIFF
--- a/lib/arkecosystem/crypto/crypto.ex
+++ b/lib/arkecosystem/crypto/crypto.ex
@@ -39,16 +39,14 @@ defmodule ArkEcosystem.Crypto.Crypto do
       |> Map.put(:sign_signature, sign_signature)
   end
 
-  # TODO: fix verify
   def verify(transaction) do
     get_bytes(transaction)
-      #|> EcKey.ecdsa_verify(transaction.signature, transaction.sender_public_key)
+      |> EcKey.verify(transaction.signature, transaction.sender_public_key)
   end
 
-  # TODO: fix verify
-  def second_verify(transaction) do
+  def second_verify(transaction, second_public_key) do
     get_bytes(transaction, false)
-      #|> EcKey.ecdsa_verify(transaction.sign_signature, transaction.sender_public_key)
+      |> EcKey.verify(transaction.sign_signature, second_public_key)
   end
 
   def get_bytes(transaction, skip_signature \\ true, skip_second_signature \\ true) do

--- a/lib/utils/ec_key.ex
+++ b/lib/utils/ec_key.ex
@@ -12,8 +12,15 @@ defmodule ArkEcosystem.Crypto.Utils.EcKey do
       )
 
     r
-    |> Der.encode_sequence(s)
-    |> Base.encode16(case: :lower)
+      |> Der.encode_sequence(s)
+      |> Base.encode16(case: :lower)
+  end
+
+  def verify(message, signature, public_key) do
+    message = :crypto.hash(:sha256, message)
+    signature = Base.decode16!(signature, case: :lower)
+    public_key = Base.decode16!(public_key, case: :lower)
+    :crypto.verify(:ecdsa, :sha256, {:digest, message}, signature, [public_key, :secp256k1])
   end
 
   def get_private_key(secret) do
@@ -51,4 +58,5 @@ defmodule ArkEcosystem.Crypto.Utils.EcKey do
     ripemd_public_key = :crypto.hash(:ripemd160, elem(public_key, 1))
     Base58Check.encode58check(network_address, ripemd_public_key)
   end
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,6 @@ defmodule ArkEcosystem.Crypto.MixProject do
       {:temp, "~> 0.4.5"},
       {:jason, "~> 1.1"},
       {:kvx, "~> 0.1"},
-
       {:mock, "~> 0.3.0", only: :test}
     ]
   end

--- a/test/crypto/builder_test.exs
+++ b/test/crypto/builder_test.exs
@@ -43,7 +43,7 @@ defmodule ArkEcosystem.Crypto.BuilderTest do
     second_public_key_address = EcKey.secret_to_public_key(context[:second_secret])
 
     assert(Crypto.verify(transaction) == true)
-    assert(Crypto.second_verify(second_public_key_address) == true)
+    assert(Crypto.second_verify(transaction, second_public_key_address) == true)
   end
 
   test "should build vote and verify", context do
@@ -66,7 +66,7 @@ defmodule ArkEcosystem.Crypto.BuilderTest do
     second_public_key_address = EcKey.secret_to_public_key(context[:second_secret])
 
     assert(Crypto.verify(transaction) == true)
-    assert(Crypto.second_verify(second_public_key_address) == true)
+    assert(Crypto.second_verify(transaction, second_public_key_address) == true)
   end
 
   test "should build second signature registration and verify", context do
@@ -77,7 +77,7 @@ defmodule ArkEcosystem.Crypto.BuilderTest do
     second_public_key_address = EcKey.secret_to_public_key(context[:second_secret])
 
     assert(Crypto.verify(transaction) == true)
-    assert(Crypto.second_verify(second_public_key_address) == true)
+    assert(Crypto.second_verify(transaction, second_public_key_address) == true)
   end
 
   test "should build delegate registration and verify", context do
@@ -96,7 +96,7 @@ defmodule ArkEcosystem.Crypto.BuilderTest do
     second_public_key_address = EcKey.secret_to_public_key(context[:second_secret])
 
     assert(Crypto.verify(transaction) == true)
-    assert(Crypto.second_verify(second_public_key_address) == true)
+    assert(Crypto.second_verify(transaction, second_public_key_address) == true)
   end
 
 end


### PR DESCRIPTION
Implement missing `verify` functionality and make all unit tests happy.

Fixes #1 .