### PR TITLE
fix: skip recipientId in to_bytes for tx type 1 and 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.1.2
+
+### Fixed
+- Skip recipient id in `to_bytes` for type 1 and 4 transactions.
+
 ## 0.1.1 - 2018-07-31
 
 ### Fixed

--- a/lib/arkecosystem/crypto/transactions/deserializer.ex
+++ b/lib/arkecosystem/crypto/transactions/deserializer.ex
@@ -271,8 +271,6 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializer do
         transaction
       end
 
-    # Calculate recipient_id after the transaction id has been computed, because of
-    # https://github.com/ArkEcosystem/core/issues/754
     case transaction.type do
       type when type in [@second_signature_registration, @multi_signature_registration] ->
         recipient_id = Address.from_public_key(transaction.sender_public_key, transaction.network)

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule ArkEcosystem.Crypto.MixProject do
       deps: deps(),
       name: "ArkEcosystem Elixir Crypto",
       source_url: "https://github.com/ArkEcosystem/elixir-crypto",
-      test_coverage: [tool: ExCoveralls],
+      test_coverage: [tool: ExCoveralls]
     ]
   end
 

--- a/test/arkecosystem/crypto/transactions/deserializers/delegate_registration_test.exs
+++ b/test/arkecosystem/crypto/transactions/deserializers/delegate_registration_test.exs
@@ -1,6 +1,7 @@
 defmodule ArkEcosystem.Crypto.Transactions.Deserializers.DelegateRegistrationTest do
   use ExUnit.Case, async: false
   alias ArkEcosystem.Crypto.Transactions.Deserializer
+  alias ArkEcosystem.Crypto.Transactions.Transaction
   alias ArkEcosystem.Test.TestHelper
 
   test "should be ok if signed with a passphrase" do
@@ -17,6 +18,7 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.DelegateRegistrationTes
     assert(actual.amount == fixture.data.amount)
     assert(actual.id == fixture.data.id)
     assert(actual.asset.delegate.username == fixture.data.asset.delegate.username)
+    assert(Transaction.verify(actual) == true)
   end
 
   test "should be ok if signed with a second passphrase" do
@@ -33,5 +35,6 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.DelegateRegistrationTes
     assert(actual.amount == fixture.data.amount)
     assert(actual.id == fixture.data.id)
     assert(actual.asset.delegate.username == fixture.data.asset.delegate.username)
+    assert(Transaction.verify(actual) == true)
   end
 end

--- a/test/arkecosystem/crypto/transactions/deserializers/multi_signature_registration_test.exs
+++ b/test/arkecosystem/crypto/transactions/deserializers/multi_signature_registration_test.exs
@@ -1,6 +1,7 @@
 defmodule ArkEcosystem.Crypto.Transactions.Deserializers.MultiSignatureRegistrationTest do
   use ExUnit.Case, async: false
   alias ArkEcosystem.Crypto.Transactions.Deserializer
+  alias ArkEcosystem.Crypto.Transactions.Transaction
   alias ArkEcosystem.Test.TestHelper
 
   test "should be ok if signed with a passphrase" do
@@ -21,5 +22,6 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.MultiSignatureRegistrat
     assert(actual.asset.multisignature.keysgroup == fixture.data.asset.multisignature.keysgroup)
     assert(actual.asset.multisignature.min == fixture.data.asset.multisignature.min)
     assert(actual.asset.multisignature.lifetime == fixture.data.asset.multisignature.lifetime)
+    assert(Transaction.verify(actual) == true)
   end
 end

--- a/test/arkecosystem/crypto/transactions/deserializers/second_signature_registration_test.exs
+++ b/test/arkecosystem/crypto/transactions/deserializers/second_signature_registration_test.exs
@@ -1,6 +1,7 @@
 defmodule ArkEcosystem.Crypto.Transactions.Deserializers.SecondSignatureRegistrationTest do
   use ExUnit.Case, async: false
   alias ArkEcosystem.Crypto.Transactions.Deserializer
+  alias ArkEcosystem.Crypto.Transactions.Transaction
   alias ArkEcosystem.Crypto.Identities.Address
   alias ArkEcosystem.Test.TestHelper
 
@@ -20,6 +21,7 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.SecondSignatureRegistra
     assert(actual.amount == fixture.data.amount)
     assert(actual.id == fixture.data.id)
     assert(actual.asset.signature.public_key == fixture.data.asset.signature.publicKey)
+    assert(Transaction.verify(actual) == true)
 
     # special case as the type 1 transaction itself has no recipientId
     assert(actual.recipient_id == Address.from_public_key(fixture.data.senderPublicKey))

--- a/test/arkecosystem/crypto/transactions/deserializers/transfer_test.exs
+++ b/test/arkecosystem/crypto/transactions/deserializers/transfer_test.exs
@@ -1,6 +1,7 @@
 defmodule ArkEcosystem.Crypto.Transactions.Deserializers.TransferTest do
   use ExUnit.Case, async: false
   alias ArkEcosystem.Crypto.Transactions.Deserializer
+  alias ArkEcosystem.Crypto.Transactions.Transaction
   alias ArkEcosystem.Test.TestHelper
 
   test "should be ok if signed with a passphrase" do
@@ -18,6 +19,7 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.TransferTest do
     assert(actual.recipient_id == fixture.data.recipientId)
     assert(actual.signature == fixture.data.signature)
     assert(actual.id == fixture.data.id)
+    assert(Transaction.verify(actual) == true)
   end
 
   test "should be ok if signed with a second passphrase" do
@@ -35,6 +37,7 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.TransferTest do
     assert(actual.recipient_id == fixture.data.recipientId)
     assert(actual.signature == fixture.data.signature)
     assert(actual.id == fixture.data.id)
+    assert(Transaction.verify(actual) == true)
   end
 
   test "should be ok if signed with a passphrase and vendor field" do
@@ -53,6 +56,7 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.TransferTest do
     assert(actual.signature == fixture.data.signature)
     assert(actual.vendor_field == fixture.data.vendorField)
     assert(actual.id == fixture.data.id)
+    assert(Transaction.verify(actual) == true)
   end
 
   test "should be ok if signed with a second passphrase and vendor field" do
@@ -74,6 +78,7 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.TransferTest do
     assert(actual.sign_signature == fixture.data.signSignature)
     assert(actual.vendor_field == fixture.data.vendorField)
     assert(actual.id == fixture.data.id)
+    assert(Transaction.verify(actual) == true)
   end
 
   test "should be ok if signed with a passphrase and vendor field hex" do
@@ -92,6 +97,7 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.TransferTest do
     assert(actual.recipient_id == fixture.data.recipientId)
     assert(actual.signature == fixture.data.signature)
     assert(actual.id == fixture.data.id)
+    assert(Transaction.verify(actual) == true)
   end
 
   test "should be ok if signed with a second passphrase and vendor field hex" do
@@ -113,5 +119,6 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.TransferTest do
     assert(actual.signature == fixture.data.signature)
     assert(actual.sign_signature == fixture.data.signSignature)
     assert(actual.id == fixture.data.id)
+    assert(Transaction.verify(actual) == true)
   end
 end

--- a/test/arkecosystem/crypto/transactions/deserializers/vote_test.exs
+++ b/test/arkecosystem/crypto/transactions/deserializers/vote_test.exs
@@ -1,6 +1,7 @@
 defmodule ArkEcosystem.Crypto.Transactions.Deserializers.VoteTest do
   use ExUnit.Case, async: false
   alias ArkEcosystem.Crypto.Transactions.Deserializer
+  alias ArkEcosystem.Crypto.Transactions.Transaction
   alias ArkEcosystem.Test.TestHelper
 
   test "should be ok if signed with a passphrase" do
@@ -18,6 +19,7 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.VoteTest do
     assert(actual.recipient_id == fixture.data.recipientId)
     assert(actual.id == fixture.data.id)
     assert(actual.asset.votes == fixture.data.asset.votes)
+    assert(Transaction.verify(actual) == true)
   end
 
   test "should be ok if signed with a second passphrase" do
@@ -36,5 +38,6 @@ defmodule ArkEcosystem.Crypto.Transactions.Deserializers.VoteTest do
     assert(actual.recipient_id == fixture.data.recipientId)
     assert(actual.id == fixture.data.id)
     assert(actual.asset.votes == fixture.data.asset.votes)
+    assert(Transaction.verify(actual) == true)
   end
 end


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
In second signature and multi signature transactions the recipient id is not supposed to be included in the signature/id calculation. Add an additional check to `to_bytes` to explicitely exclude the recipientId. This also allows such transactions to be verified, even if the recipientId is set.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
<!--